### PR TITLE
Corrigindo palavras soletradas erroneamente README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Stalkers are not allowed
 
 # TODO
 - [X] task 01: Develop initial room management system
-- [ ] task 02: Implement session to separete different players
+- [ ] task 02: Implement session to separate different players
 - [ ] task 03: Implement the entire game logic
 - [ ] task 04: Make things work better and fix bugs
 - [ ] task 05: Make management system delete old rooms (i'm not in the mood to do this yet)
-- [ ] task 06: Make some info be sincronized with the server, like players
+- [ ] task 06: Make some info be synchronized with the server, like players
 - [ ] task 07: Make friends to play this game with me (most difficult step)


### PR DESCRIPTION
Caro amigo,

Por meio deste venho mostrar o resultado do que foram meses de pesquisa atrás de um bug que me incomodava há tempos no sistema. Fui descobrir que a causa estava na soletração das seguintes palavras: **separeted** e **sincronized**.

De forma alguma tais erros devem ser vistos com olhos perniciosos, visto que são erros deveras comumente ocasionados, como fortemente evidenciado por pesquisas do mais alto calibre feitas pela [_Wikipedia_](https://en.wikipedia.org/wiki/Commonly_misspelled_English_words#R%E2%80%93S) e pela [_TheKnowledgeAcademy_](https://www.theknowledgeacademy.com/blog/google-reveals-the-most-common-misspelt-words/).

Deixo aqui algumas sugestões de mneturmadamônicos lúdicos:

- Lembre-se, caro amigo, que para os nativos de língua inglesa, a separação vem sempre acompanhada do rato (**rat** - sepa**rat**ed).
- Para eles, a separação é sempre um grito prolongado: AA!!! (sep**A**r**A**ted).
- _"Ou, ou, ou! Para com essa briga, para já! Que que está acontecendo com vocês dois? Vão se machucar mesmo? Como assim vocês estão brigando porque o Teodósio comeu o último pedaço de paçoquinha? Isso não é motivo pra briga. Separa agora, Teodósio! Separa!"_ (**Separa**, **Ted**).

P.S.: Não deixe minhas preferências segurarem suas tendências anglo-saxãs. Em Britânia, você é livre para erradicar a temível letra Z. Use **synchronise!** enquanto balança sua varinha de condão de _Harry Potter_!